### PR TITLE
Fix Cover object

### DIFF
--- a/demo/cover.html
+++ b/demo/cover.html
@@ -13,105 +13,114 @@
     </head>
     <body>
 
-        <style>
-            .o-cover__img--demo {
-                width: 100%;
-                height: 250px;
-            }
-        </style>
+      <style>
+        .o-cover--demo {
+          height: 250px;
+        }
+      </style>
 
-        <h1>Cover Object</h1>
-        (<a target="_blank" title="Cover Object Codepen" href="https://codepen.io/afontcu/pen/PmeYxP?editors=1100">Codepen</a>)
-        <hr />
-
-
-        <p>Place any text as a cover from an image.</p>
-        <div class="o-cover">
-            <div class="o-cover__img o-cover__img--demo"></div>
-            <div class="o-cover__body">
-                Lorem ipsum dolor sit amet
-            </div>
-        </div>
+      <h1>Cover Object</h1>
+      (<a target="_blank" title="Cover Object Codepen" href="https://codepen.io/afontcu/pen/PmeYxP?editors=1100">Codepen</a>)
+      <hr />
 
 
-        <h3>Size modifiers</h3>
-        <hr />
-
-        <p>Flush</p>
-        <div class="o-cover o-cover--flush">
-            <div class="o-cover__img o-cover__img--demo"></div>
-            <div class="o-cover__body">
-                Lorem ipsum dolor sit amet
-            </div>
-        </div>
-
-        <p>Tiny</p>
-        <div class="o-cover o-cover--tiny">
-            <div class="o-cover__img o-cover__img--demo"></div>
-            <div class="o-cover__body">
-                Lorem ipsum dolor sit amet
-            </div>
-        </div>
-
-        <p>Small</p>
-        <div class="o-cover o-cover--small">
-            <div class="o-cover__img o-cover__img--demo"></div>
-            <div class="o-cover__body">
-                Lorem ipsum dolor sit amet
-            </div>
-        </div>
-
-        <p>Large</p>
-        <div class="o-cover o-cover--large">
-            <div class="o-cover__img o-cover__img--demo"></div>
-            <div class="o-cover__body">
-                Lorem ipsum dolor sit amet
-            </div>
-        </div>
-
-        <p>Huge</p>
-        <div class="o-cover o-cover--huge">
-            <div class="o-cover__img o-cover__img--demo"></div>
-            <div class="o-cover__body">
-                Lorem ipsum dolor sit amet
-            </div>
-        </div>
+      <p>Place any text as a cover from an image.</p>
+      <div
+        style="background-image:url('http://unsplash.it/960/600')"
+        class="o-cover o-cover--demo">
+          <div class="o-cover__body">
+              Lorem ipsum dolor sit amet
+          </div>
+      </div>
 
 
-        <h3>Alignment modifiers</h3>
-        <hr />
+      <h3>Size modifiers</h3>
+      <hr />
 
-        <p>Top</p>
-        <div class="o-cover o-cover--top">
-            <div class="o-cover__img o-cover__img--demo"></div>
-            <div class="o-cover__body">
-                Lorem ipsum dolor sit amet
-            </div>
-        </div>
+      <p>Flush</p>
+      <div
+        style="background-image:url('http://unsplash.it/960/600')"
+        class="o-cover o-cover--flush o-cover--demo">
+          <div class="o-cover__body">
+              Lorem ipsum dolor sit amet
+          </div>
+      </div>
 
-        <p>Bottom</p>
-        <div class="o-cover o-cover--bottom">
-            <div class="o-cover__img o-cover__img--demo"></div>
-            <div class="o-cover__body">
-                Lorem ipsum dolor sit amet
-            </div>
-        </div>
+      <p>Tiny</p>
+      <div
+        style="background-image:url('http://unsplash.it/960/600')"
+        class="o-cover o-cover--tiny o-cover--demo">
+          <div class="o-cover__body">
+              Lorem ipsum dolor sit amet
+          </div>
+      </div>
 
-        <p>Left</p>
-        <div class="o-cover o-cover--left">
-            <div class="o-cover__img o-cover__img--demo"></div>
-            <div class="o-cover__body">
-                Lorem ipsum dolor sit amet
-            </div>
-        </div>
+      <p>Small</p>
+      <div
+        style="background-image:url('http://unsplash.it/960/600')"
+        class="o-cover o-cover--small o-cover--demo">
+          <div class="o-cover__body">
+              Lorem ipsum dolor sit amet
+          </div>
+      </div>
 
-        <p>Right</p>
-        <div class="o-cover o-cover--right">
-            <div class="o-cover__img o-cover__img--demo"></div>
-            <div class="o-cover__body">
-                Lorem ipsum dolor sit amet
-            </div>
-        </div>
+      <p>Large</p>
+      <div
+        style="background-image:url('http://unsplash.it/960/600')"
+        class="o-cover o-cover--large o-cover--demo">
+          <div class="o-cover__body">
+              Lorem ipsum dolor sit amet
+          </div>
+      </div>
+
+      <p>Huge</p>
+      <div
+        style="background-image:url('http://unsplash.it/960/600')"
+        class="o-cover o-cover--huge o-cover--demo">
+          <div class="o-cover__body">
+              Lorem ipsum dolor sit amet
+          </div>
+      </div>
+
+
+      <h3>Alignment modifiers</h3>
+      <hr />
+
+      <p>Top</p>
+      <div
+        style="background-image:url('http://unsplash.it/960/600')"
+        class="o-cover o-cover--top o-cover--demo">
+          <div class="o-cover__body">
+              Lorem ipsum dolor sit amet
+          </div>
+      </div>
+
+      <p>Bottom</p>
+      <div
+        style="background-image:url('http://unsplash.it/960/600')"
+        class="o-cover o-cover--bottom o-cover--demo">
+          <div class="o-cover__body">
+              Lorem ipsum dolor sit amet
+          </div>
+      </div>
+
+      <p>Left</p>
+      <div
+        style="background-image:url('http://unsplash.it/960/600')"
+        class="o-cover o-cover--left o-cover--demo">
+          <div class="o-cover__body">
+              Lorem ipsum dolor sit amet
+          </div>
+      </div>
+
+      <p>Right</p>
+      <div
+        style="background-image:url('http://unsplash.it/960/600')"
+        class="o-cover o-cover--right o-cover--demo">
+          <div class="o-cover__body">
+              Lorem ipsum dolor sit amet
+          </div>
+      </div>
 
   </body>
 </html>

--- a/output.css
+++ b/output.css
@@ -1044,16 +1044,20 @@ h6 {
    ========================================================================== */
 /**
  * Place any text as a cover from an image.
+ *
+ * 1. Opinionated placement of background image.
  */
 .o-cover {
-  display: block; }
-
-.o-cover__img {
-  max-width: 100%;
-  display: flex; }
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-position: center;
+  /* [1] */
+  background-size: cover;
+  /* [1] */ }
 
 /**
- * 1. Center the body into the parent element. More info about `margin: auto`
+ * 1. Center the body into parent element.
  *    https://hackernoon.com/flexbox-s-best-kept-secret-bd3d892826b6
  */
 .o-cover__body {
@@ -1061,12 +1065,12 @@ h6 {
   /* 1 */
   padding: 24px;
   /* Size variants.
-        ===================================================================== */
+    ========================================================================= */
   /* Alignment variants.
     ========================================================================= */
   /**
-    * Vertically align the image- and body-content differently.
-    */ }
+   * Vertically align the image- and body-content differently.
+   */ }
   .o-cover--flush .o-cover__body {
     padding: 0; }
   .o-cover--tiny .o-cover__body {

--- a/scss/5-Objects/_objects.cover.scss
+++ b/scss/5-Objects/_objects.cover.scss
@@ -4,21 +4,22 @@
 
 /**
  * Place any text as a cover from an image.
+ *
+ * 1. Opinionated placement of background image.
  */
 
 .o-cover {
-  display: block;
-}
-
-
-.o-cover__img {
-  max-width: 100%;
   display: flex;
+  align-items: center;
+  justify-content: center;
+
+  background-position: center; /* [1] */
+  background-size: cover; /* [1] */
 }
 
 
 /**
- * 1. Center the body into the parent element. More info about `margin: auto`
+ * 1. Center the body into parent element.
  *    https://hackernoon.com/flexbox-s-best-kept-secret-bd3d892826b6
  */
 
@@ -31,7 +32,7 @@
 
 
   /* Size variants.
-        ===================================================================== */
+    ========================================================================= */
 
   .o-cover--flush & {
     padding: 0;
@@ -61,8 +62,8 @@
     ========================================================================= */
 
   /**
-    * Vertically align the image- and body-content differently.
-    */
+   * Vertically align the image- and body-content differently.
+   */
 
   .o-cover--top & {
     margin-top: 0;


### PR DESCRIPTION
En algun moment s'havia perdut la implementació del Cover.

He aprofitat per actualitzar-ne la interfície, penso que l'ús que ha de tenir correspon més a un `background-image` que no pas a una imatge en si. No se m'acut cap ús on la imatge de fons hagi de ser una imatge, ja que sempre actua com a acompanyant del text i no com a element semàntic.

