### PR TITLE
Color utilities

### DIFF
--- a/output.css
+++ b/output.css
@@ -50,10 +50,17 @@
    COLORS SETTINGS
    ========================================================================== */
 /**
- * Branding colors.
- */
-/**
- * Notification colors.
+ * The global colors file contains any project-wide color variables. Please
+ * maintain this file as short as possible, trying to avoid variables for
+ * similar colors.
+ *
+ *
+ * Since we don't have color variables but color maps, you need to use the
+ * `map-get` Sass function if you want to use a specific color:
+ *
+ * .c-some-component {
+ *   border-color: map-get($global-colors, "branding-primary");
+ * }
  */
 /* ==========================================================================
    TOOLS
@@ -943,6 +950,39 @@ h6 {
   content: "" !important;
   display: block !important;
   clear: both !important; }
+
+/* ==========================================================================
+   #COLOR UTILITY
+   ========================================================================== */
+.u-text-branding-primary {
+  color: #acc743; }
+
+.u-background-branding-primary {
+  background-color: #acc743; }
+
+.u-text-notify-success {
+  color: #4caf50; }
+
+.u-background-notify-success {
+  background-color: #4caf50; }
+
+.u-text-notify-info {
+  color: #29b6f6; }
+
+.u-background-notify-info {
+  background-color: #29b6f6; }
+
+.u-text-notify-warning {
+  color: #ff9800; }
+
+.u-background-notify-warning {
+  background-color: #ff9800; }
+
+.u-text-notify-danger {
+  color: #f44336; }
+
+.u-background-notify-danger {
+  background-color: #f44336; }
 
 /* ==========================================================================
    #FLEXBOX UTILITY

--- a/output.css
+++ b/output.css
@@ -55,6 +55,14 @@
  * similar colors.
  *
  *
+ *
+ * To add or modify the $global-colors map you can use our custom map-add tool
+ * in your custom _settings.colors.scss file:
+ *
+ * $global-colors: map-add($global-colors, "branding-primary", #c0ffee);
+ *
+ *
+ *
  * Since we don't have color variables but color maps, you need to use the
  * `map-get` Sass function if you want to use a specific color:
  *

--- a/scss/1-Settings/_settings.colors.scss
+++ b/scss/1-Settings/_settings.colors.scss
@@ -3,17 +3,29 @@
    ========================================================================== */
 
 /**
- * Branding colors.
+ * The global colors file contains any project-wide color variables. Please
+ * maintain this file as short as possible, trying to avoid variables for
+ * similar colors.
+ *
+ *
+ * Since we don't have color variables but color maps, you need to use the
+ * `map-get` Sass function if you want to use a specific color:
+ *
+ * .c-some-component {
+ *   border-color: map-get($global-colors, "branding-primary");
+ * }
  */
 
-$color-branding-primary: #acc743;
+$global-branding-colors: (
+  "branding-primary": #acc743
+);
+
+$global-notify-colors: (
+  "notify-success": #4caf50,
+  "notify-info": #29b6f6,
+  "notify-warning": #ff9800,
+  "notify-danger": #f44336,
+);
 
 
-/**
- * Notification colors.
- */
-
-$color-notify-success: #4caf50;
-$color-notify-info: #29b6f6;
-$color-notify-warning: #ff9800;
-$color-notify-danger: #f44336;
+$global-colors: map-merge($global-branding-colors, $global-notify-colors);

--- a/scss/1-Settings/_settings.colors.scss
+++ b/scss/1-Settings/_settings.colors.scss
@@ -8,6 +8,14 @@
  * similar colors.
  *
  *
+ *
+ * To add or modify the $global-colors map you can use our custom map-add tool
+ * in your custom _settings.colors.scss file:
+ *
+ * $global-colors: map-add($global-colors, "branding-primary", #c0ffee);
+ *
+ *
+ *
  * Since we don't have color variables but color maps, you need to use the
  * `map-get` Sass function if you want to use a specific color:
  *
@@ -16,16 +24,11 @@
  * }
  */
 
-$global-branding-colors: (
-  "branding-primary": #acc743
-);
+$global-colors: (
+  "branding-primary": #acc743,
 
-$global-notify-colors: (
   "notify-success": #4caf50,
   "notify-info": #29b6f6,
   "notify-warning": #ff9800,
   "notify-danger": #f44336,
 );
-
-
-$global-colors: map-merge($global-branding-colors, $global-notify-colors);

--- a/scss/2-Tools/_tools.map.scss
+++ b/scss/2-Tools/_tools.map.scss
@@ -1,0 +1,13 @@
+/* ==========================================================================
+   MAP TOOLS
+   ========================================================================== */
+
+/**
+ * A simple tool to simplify map-merge public API
+ *
+ * $some-map: map-add($some-map, "new-map-key", "new-map-value");
+ */
+
+@function map-add($map, $key, $value) {
+  @return map-merge($map, ($key: $value));
+}

--- a/scss/7-Utilities/_main.scss
+++ b/scss/7-Utilities/_main.scss
@@ -22,6 +22,7 @@
  */
 
 @import "utilities.clearfix";
+@import "utilities.colors";
 @import "utilities.flexbox";
 @import "utilities.hidden";
 @import "utilities.print";

--- a/scss/7-Utilities/_utilities.colors.scss
+++ b/scss/7-Utilities/_utilities.colors.scss
@@ -1,0 +1,13 @@
+/* ==========================================================================
+   #COLOR UTILITY
+   ========================================================================== */
+
+@each $name, $value in $global-colors {
+  .u-text-#{$name} {
+    color: $value;
+  }
+
+  .u-background-#{$name} {
+    background-color: $value;
+  }
+}


### PR DESCRIPTION
Vàries vegades ens hem trobat la necessitat de definir una classe solament per donar un color a un text o el background d'un element. És més lògic que el framework proporcioni aquestes classes enlloc d'haver d'omplir el projecte d'elements o modificadors que només canviïn un color, que és una situació habitual.