### PR TITLE
Deploy docs to Github Pages

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in the repo.
+*       @afontcu @xevops @oriolfg @kicaal @Pijuli

--- a/README.md
+++ b/README.md
@@ -2,25 +2,33 @@
 
 Normandy is a CSS boilerplate that gives you an initial structure for your CSS.
 
-It is not a UI library, a framework, or a complete CSS solution that you can plug in and call it a day.
+It's build upon
+[ITCSS](https://www.creativebloq.com/web-design/manage-large-css-projects-itcss-101517528),
+[BEM](http://getbem.com/naming/) and
+[OOCSS](https://www.smashingmagazine.com/2011/12/an-introduction-to-object-oriented-css-oocss/).
+Normandy is a customized version of
+[inuitcss](https://github.com/inuitcss/inuitcss).
 
-It's build upon [ITCSS](https://www.creativebloq.com/web-design/manage-large-css-projects-itcss-101517528), [BEM](http://getbem.com/naming/) and [OOCSS](https://www.smashingmagazine.com/2011/12/an-introduction-to-object-oriented-css-oocss/). Normandy is a customized version of [inuitcss](https://github.com/inuitcss/inuitcss).
 
-Want to read more about Normandy? Check out the underlying principles on [Gitbook](https://afontcu.gitbooks.io/normandy).
+## Documentation
 
+To check out our Getting Started and References documentation, visit our [Github
+Pages](https://calidae.github.io/normandy-css/).
 
 
 ## Installation
 
-You can install Normandy via npm:
+You can install Normandy from npm:
 
 ```shell
 npm install --save-dev normandy-css
 ```
 
-Since Normandy is using Sass, you will need to add its core files to your own `main.scss`.
+Since Normandy is using Sass, you will need to add its core files to your own
+`main.scss`.
 
-We recommend a structure as follows, where you zip Normandy layers with your own:
+We recommend a structure as follows, where you zip Normandy layers with your
+own:
 
 ```scss
 @import "/node_modules/normandy-css/scss/1-Settings/main";
@@ -45,78 +53,48 @@ We recommend a structure as follows, where you zip Normandy layers with your own
 @import "/my/path/to/scss/7-Utilities/main";
 ```
 
-This way, you maintain the desired layer structure while allowing your values to override Normandy's.
-
-
-
-## Initial configuration
-
-Normandy is built upon some [design system principles](https://medium.muz.li/what-is-a-design-system-1e43d19e7696) that allow the user to customize the whole CSS output.
-
-The idea is that Normandy provides you with customizable constraints (specific values for spacing, colors, text sizes...) and a toolset of objects and utilities to build your interfaces.
-
-The core variables of the boilerplate are placed in, well, the core file, `1-Settings/_settings.core.scss`:
-
-```scss
-$global-baseline: 6px;
-
-$unit-factor-tiny:   1 !default;
-$unit-factor-small:  2 !default;
-$unit-factor:        4 !default;
-$unit-factor-large:  8 !default;
-$unit-factor-huge:  16 !default;
-
-$global-font-size:   16px;
-$global-line-height: 24px;
-```
-
-Our recommendation is to **customize core variables at the beginning of the project**. The value of these variables have implications in almost every layer, thus changing them in an ongoing project could carry undesired side effects.
-
-
-
-## Daily usage
-
-The idea behind Normandy is to use a [utility-first](https://adamwathan.me/css-utility-classes-and-separation-of-concerns/) approach, where you use the Utilities layer to create your UI, and the abstract out your components when you see repeating patterns.
-
-This utility-first approach, with the constraints of a design system, allows you to create consistent layouts.
-
-Picture this: you need to define a proportional CSS Grid gap in order to achieve a sensible [vertical rythm](https://zellwk.com/blog/why-vertical-rhythms/). You would do something like this:
-
-```scss
-.c-component__grid {
-  display: grid;
-  grid-gap: $global-spacing-unit-small;
-}
-```
+This way, you maintain the desired layer structure while allowing your values to
+override Normandy's.
 
 
 ## FAQs
 
 ### "I want to play with Normandy!"
 
-Great! There's an `output.css` file in the root directory of the project with the compiled version of the default values. Feel free to grab this file and add it to any Codepen, Fiddle or Codesandbox. Bear in mind that you won't be able to benefit from Sass variables (obvs) and other goodies.
+Great! There's an `output.css` file in the root directory of the project with
+the compiled version of the default values. Feel free to grab this file and add
+it to any Codepen, Fiddle or Codesandbox.
+
+Bear in mind that you won't be able to benefit from Sass variables (obvs) and
+other goodies.
+
+Also, please notice that Normandy isn't intended to be used this way. You should
+customize its Settings to match your design guidelines.
 
 
 ### "I want to contribute"
 
-Lovely ❤️. We are open to any kind of input. Feel free to submit issues or PRs to the repository!
+Lovely ❤️. We are open to any kind of input. Feel free to submit issues or PRs
+to the repository!
 
-To start developing you should:
+First you'll need to install dependencies:
 
-Install dependencies
-```
+```shell
 npm install
 ```
-Start a watcher
-```
+
+Then, run the following script to compile Sass. This will lint on save and update the `output.css` file.
+
+```shell
 npm start
 ````
-This way, output.css will be updated automatically on every change you make.
 
-Remember, also, to run
-```
+
+Also remember to pass the linters and tests!
+
+```shell
 npm test
 ````
-before doing a PR in order to pass the tests!
+
 
 Enjoy!

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh
+
+# abort on errors
+set -e
+
+# build
+npm run docs:build
+
+# navigate into the build output directory
+cd docs/.vuepress/dist
+
+# uncomment when deploying to custom domain
+# echo 'www.example.com' > CNAME
+
+git init
+git add -A
+git commit -m 'deploy'
+
+git push -f git@github.com:calidae/normandy-css.git master:gh-pages
+
+cd -

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  base: '/normandy-css/',
   title: 'NormandyCSS',
   themeConfig: {
     repo: 'calidae/normandy-css',


### PR DESCRIPTION
Now that we have `vuepress` based docs, we can deploy them using github pages.

Haven't (obviously) tried the `deploy.sh` script. Hard to do without actually deploying the site :) As long as it looks good, I'll amend any issue once the PR gets merged.

btw, I think docs CI will be still missing. However, the ran script should be exactly the same.